### PR TITLE
Fix for alpine:latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 COPY ./ /app
 WORKDIR /app
-RUN apk add --no-cache llvm-libunwind \
+RUN apk add --no-cache libgcc \
     && apk add --no-cache --virtual .build-rust rust cargo \
     && cargo build --release \
     && cp target/release/mini-docker-rust . \


### PR DESCRIPTION
libgcc is required for rust on alpine 3.7