### PR TITLE
Patch 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start with a rust alpine image
-FROM rust:1-alpine3.13
+FROM rust:1.57-alpine
 # This is important, see https://github.com/rust-lang/docker-rust/issues/85
 ENV RUSTFLAGS="-C target-feature=-crt-static"
 # if needed, add additional dependencies here

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN cargo build --release
 RUN strip target/release/mini-docker-rust
 
 # use a plain alpine image, the alpine version needs to match the builder
-FROM alpine:3.15
+FROM alpine:3.14
 # if needed, install additional dependencies here
 RUN apk add --no-cache libgcc
 # copy the binary into the final image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start with a rust alpine image
-FROM rust:1.57-alpine
+FROM rust:1-alpine3.14
 # This is important, see https://github.com/rust-lang/docker-rust/issues/85
 ENV RUSTFLAGS="-C target-feature=-crt-static"
 # if needed, add additional dependencies here

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN cargo build --release
 RUN strip target/release/mini-docker-rust
 
 # use a plain alpine image, the alpine version needs to match the builder
-FROM alpine:3.13
+FROM alpine:3.15
 # if needed, install additional dependencies here
 RUN apk add --no-cache libgcc
 # copy the binary into the final image


### PR DESCRIPTION
This patch has two small updates:

1. Update to a easier to read Rust version number (from rust:1-alpine3.13 to 1.57-alpine)
2. Updated Rust to 1.57
3. Alpine Linux 3.15 update

With the changes, the container size is 6.01MB.