### PR TITLE
Transition to circle from travis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,12 @@
+sudo: required
+
+language: rust
+
+services:
+- docker
+
+before_install:
+- docker build -t mini-docker-rust .
+
+script:
+- docker run mini-docker-rust

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
+version: 2
 jobs:
-  build:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - checkout
-      - run: docker build -t mini-docker-rust .
-      - run: docker run mini-docker-rust
+ build:
+   machine: true
+   steps:
+     - checkout
+     - run: docker build -t mini-docker-rust .
+     - run: docker run mini-docker-rust

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,8 @@
-sudo: required
-
-language: rust
-
-services:
-- docker
-
-before_install:
-- docker build -t mini-docker-rust .
-
-script:
-- docker run mini-docker-rust
+jobs:
+  build:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - run: docker build -t mini-docker-rust .
+      - run: docker run mini-docker-rust

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mini-docker-rust [![CircleCI](https://circleci.com/gh/kpcyrd/mini-docker-rust/tree/main.svg?style=svg)](https://circleci.com/gh/kpcyrd/mini-docker-rust/tree/main)
+# mini-docker-rust [![CircleCI](https://circleci.com/gh/parasew/mini-docker-rust/tree/main.svg?style=svg)](https://circleci.com/gh/parasew/mini-docker-rust/tree/main)
 
 Very small rust docker image.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
-# mini-docker-rust [![travis][travis-image]][travis-url]
-
-[travis-image]: https://img.shields.io/travis/kpcyrd/mini-docker-rust/master.svg
-[travis-url]: https://travis-ci.com/kpcyrd/mini-docker-rust
+# mini-docker-rust [![CircleCI](https://circleci.com/gh/parasew/mini-docker-rust/tree/main.svg?style=svg)](https://circleci.com/gh/parasew/mini-docker-rust/tree/main)
 
 Very small rust docker image.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mini-docker-rust [![travis][travis-image]][travis-url]
 
 [travis-image]: https://img.shields.io/travis/kpcyrd/mini-docker-rust/master.svg
-[travis-url]: https://travis-ci.org/kpcyrd/mini-docker-rust
+[travis-url]: https://travis-ci.com/kpcyrd/mini-docker-rust
 
 Very small rust docker image.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mini-docker-rust [![CircleCI](https://circleci.com/gh/parasew/mini-docker-rust/tree/main.svg?style=svg)](https://circleci.com/gh/parasew/mini-docker-rust/tree/main)
+# mini-docker-rust [![CircleCI](https://circleci.com/gh/kpcyrd/mini-docker-rust/tree/main.svg?style=svg)](https://circleci.com/gh/kpcyrd/mini-docker-rust/tree/main)
 
 Very small rust docker image.
 


### PR DESCRIPTION
Travis CI have changed their plans, so the CI tests do not run for the project (and they are displaying in the Github repo as 'failed', but they just don't run because there are not enough credits on the account).  In this patch I have added the correct badge from circleci (you just need to create a free account there and link it with Github). The task I have ported to circleci system and tested (see https://circleci.com/gh/parasew/mini-docker-rust/tree/main.svg?style=svg )
